### PR TITLE
Remove z2.installProducts. Use testing best practices.

### DIFF
--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -173,6 +173,11 @@ def prepare_render(configurator):
     # package.dottedname = 'collective.foo.something'
     configurator.variables['package.dottedname'] = dottedname
 
+    # package.uppercasename = 'COLLECTIVE_FOO_SOMETHING'
+    configurator.variables['package.uppercasename'] = configurator.variables[
+        'package.dottedname'
+    ].replace('.', '_').upper()
+
     camelcasename = dottedname.replace('.', ' ').title().replace(' ', '')
     browserlayer = "{0}Layer".format(camelcasename)
 

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/testing.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/testing.py.bob
@@ -38,8 +38,6 @@ class {{{ package.browserlayer }}}(PloneSandboxLayer):
         # Load ZCML
         self.loadZCML(package={{{ package.dottedname }}},
                       name='testing.zcml')
-        for product in self.products:
-            z2.installProduct(app, product)
 
     def setUpPloneSite(self, portal):
         """Set up Plone."""
@@ -49,11 +47,6 @@ class {{{ package.browserlayer }}}(PloneSandboxLayer):
         # Login and create some test content
         setRoles(portal, TEST_USER_ID, ['Manager'])
         login(portal, TEST_USER_NAME)
-
-    def tearDownZope(self, app):
-        """Tear down Zope."""
-        for product in reversed(self.products):
-            z2.uninstallProduct(app, product)
 
 
 FIXTURE = {{{ package.browserlayer }}}(

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/testing.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/testing.py.bob
@@ -29,9 +29,6 @@ class {{{ package.browserlayer }}}(PloneSandboxLayer):
 {{% if not plone.is_plone5 %}}
     defaultBases = (PLONE_FIXTURE,)
 {{% endif %}}
-    products = [
-        '{{{ package.dottedname }}}',
-    ]
 
     def setUpZope(self, app, configurationContext):
         """Set up Zope."""
@@ -49,24 +46,22 @@ class {{{ package.browserlayer }}}(PloneSandboxLayer):
         login(portal, TEST_USER_NAME)
 
 
-FIXTURE = {{{ package.browserlayer }}}(
-    name='FIXTURE'
-    )
+{{{package.uppercasename}}}_FIXTURE = {{{ package.browserlayer }}}()
 
 
-INTEGRATION = IntegrationTesting(
-    bases=(FIXTURE,),
-    name='INTEGRATION'
-    )
+{{{package.uppercasename}}}_INTEGRATION_TESTING = IntegrationTesting(
+    bases=({{{package.uppercasename}}}_FIXTURE,),
+    name='{{{ package.browserlayer }}}:IntegrationTesting'
+)
 
 
-FUNCTIONAL = FunctionalTesting(
-    bases=(FIXTURE,),
-    name='FUNCTIONAL'
-    )
+{{{package.uppercasename}}}_FUNCTIONAL_TESTING = FunctionalTesting(
+    bases=({{{package.uppercasename}}}_FIXTURE,),
+    name='{{{ package.browserlayer }}}:FunctionalTesting'
+)
 
 
-ACCEPTANCE = FunctionalTesting(
-    bases=(FIXTURE, AUTOLOGIN_LIBRARY_FIXTURE, z2.ZSERVER_FIXTURE),
-    name='ACCEPTANCE'
-    )
+{{{package.uppercasename}}}_ACCEPTANCE_TESTING = FunctionalTesting(
+    bases=({{{package.uppercasename}}}_FIXTURE, AUTOLOGIN_LIBRARY_FIXTURE, z2.ZSERVER_FIXTURE),
+    name='{{{ package.browserlayer }}}:AcceptanceTesting'
+)

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_robot.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_robot.py.bob
@@ -1,5 +1,5 @@
 # -*- coding: UTF-8 -*-
-from {{{ package.dottedname }}}.testing import ACCEPTANCE
+from {{{ package.dottedname }}}.testing import {{{package.uppercasename}}}_ACCEPTANCE_TESTING  # noqa
 from plone.testing import layered
 
 import os
@@ -19,7 +19,7 @@ def test_suite():
         suite.addTests([
             layered(
                 robotsuite.RobotTestSuite(test),
-                layer=ACCEPTANCE
+                layer={{{package.uppercasename}}}_ACCEPTANCE_TESTING
             ),
         ])
     return suite

--- a/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
+++ b/bobtemplates/plone_addon/src/+package.namespace+/+package.name+/tests/test_setup.py.bob
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup/installation tests for this package."""
-from {{{ package.dottedname }}}.testing import INTEGRATION
+from {{{ package.dottedname }}}.testing import {{{package.uppercasename}}}_INTEGRATION_TESTING  # noqa
 from plone import api
 
 import unittest2 as unittest
@@ -9,7 +9,7 @@ import unittest2 as unittest
 class TestInstall(unittest.TestCase):
     """Test installation of {{{ package.dottedname }}} into Plone."""
 
-    layer = INTEGRATION
+    layer = {{{package.uppercasename}}}_INTEGRATION_TESTING
 
     def setUp(self):
         """Custom shared utility setup for tests."""

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -28,7 +28,7 @@ input = inline:
    python bootstrap-buildout.py --setuptools-version=8.3
    ${buildout:directory}/test.plone_addon/bin/buildout
    ${buildout:directory}/test.plone_addon/bin/test
-   rm -rf ${buildout:directory}/test.plone_addon/
+   # rm -rf ${buildout:directory}/test.plone_addon/
 output = ${buildout:directory}/bin/test
 mode = 755
 


### PR DESCRIPTION
 I think we can safely expect that we are not dealing with old zope2 only packages in 2015.